### PR TITLE
Implement plugin to wrap kubectl

### DIFF
--- a/cmd/cli/plugin/kubectl/README.md
+++ b/cmd/cli/plugin/kubectl/README.md
@@ -1,0 +1,3 @@
+# kubectl
+
+A plugin that integrates the native `kubectl` tool into the `tanzu` CLI.

--- a/cmd/cli/plugin/kubectl/doc.go
+++ b/cmd/cli/plugin/kubectl/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+kubectl
+*/
+package main

--- a/cmd/cli/plugin/kubectl/main.go
+++ b/cmd/cli/plugin/kubectl/main.go
@@ -1,0 +1,101 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/aunum/log"
+	"github.com/spf13/cobra"
+
+	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
+)
+
+var descriptor = cliv1alpha1.PluginDescriptor{
+	Name:           "kubectl",
+	Description:    "Full kubectl functionality in tanzu",
+	Group:          cliv1alpha1.ExtraCmdGroup,
+	Aliases:        []string{"k", "kctl", "kube"},
+	CompletionType: cliv1alpha1.NativePluginCompletion,
+}
+
+func main() {
+	p, err := plugin.NewPlugin(&descriptor)
+	if err != nil {
+		log.Fatal(err)
+	}
+	p.Cmd.DisableFlagParsing = true
+	p.Cmd.Args = cobra.ArbitraryArgs
+	p.Cmd.CompletionOptions.DisableDefaultCmd = true
+
+	p.Cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		path, err := exec.LookPath("kubectl")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Unable to find 'kubectl' on your system.  Please install it and make sure it is on $PATH")
+			return err
+		}
+
+		execCmd := exec.Command(path, args...)
+
+		execCmd.Stdin = os.Stdin
+		execCmd.Stderr = os.Stderr
+		execCmd.Stdout = os.Stdout
+
+		return execCmd.Run()
+	}
+
+	p.Cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		path, err := exec.LookPath("kubectl")
+		if err != nil {
+			cobra.CompErrorln("Unable to find 'kubectl' on your system.  Please install it and make sure it is on $PATH")
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		finalArgs := []string{cobra.ShellCompRequestCmd}
+		finalArgs = append(finalArgs, args...)
+		finalArgs = append(finalArgs, toComplete)
+		execCmd := exec.Command(path, finalArgs...)
+		execCmd.Stdin = os.Stdin
+		execCmd.Stderr = os.Stderr
+		buf := new(bytes.Buffer)
+		execCmd.Stdout = buf
+
+		err = execCmd.Run()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		var completions []string
+		for _, comp := range strings.Split(buf.String(), "\n") {
+			// Remove any empty lines
+			if len(comp) > 0 {
+				completions = append(completions, comp)
+			}
+		}
+
+		// Check the last line of output for the completion directive
+		// of the form :<integer>
+		directive := cobra.ShellCompDirectiveDefault
+		if len(completions) > 0 {
+			lastLine := completions[len(completions)-1]
+			if len(lastLine) > 1 && lastLine[0] == ':' {
+				if strInt, err := strconv.Atoi(lastLine[1:]); err == nil {
+					directive = cobra.ShellCompDirective(strInt)
+					completions = completions[:len(completions)-1]
+				}
+			}
+		}
+		return completions, directive
+	}
+
+	if err := p.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/cli/plugin/kubectl/test/main.go
+++ b/cmd/cli/plugin/kubectl/test/main.go
@@ -1,0 +1,42 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
+)
+
+var descriptor = cli.NewTestFor("kubectl")
+
+func main() {
+	retcode := 0
+
+	defer func() { os.Exit(retcode) }()
+	defer Cleanup()
+
+	p, err := plugin.NewPlugin(descriptor)
+	if err != nil {
+		log.Println(err)
+		retcode = 1
+		return
+	}
+	p.Cmd.RunE = test
+	if err := p.Execute(); err != nil {
+		retcode = 1
+		return
+	}
+}
+
+func test(c *cobra.Command, _ []string) error {
+	return nil
+}
+
+// Cleanup the test.
+func Cleanup() {}

--- a/common.mk
+++ b/common.mk
@@ -52,7 +52,7 @@ LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.Version
 
 # Add supported OS-ARCHITECTURE combinations here
 ENVS ?= linux-amd64 windows-amd64 darwin-amd64
-STANDALONE_PLUGINS ?= login management-cluster package pinniped-auth secret telemetry
+STANDALONE_PLUGINS ?= login management-cluster package pinniped-auth secret telemetry kubectl
 CONTEXTAWARE_PLUGINS ?= cluster kubernetes-release feature
 ADMIN_PLUGINS ?= builder codegen test
 PLUGINS ?= $(STANDALONE_PLUGINS) $(CONTEXTAWARE_PLUGINS)


### PR DESCRIPTION
### What this PR does / why we need it

This is an exercise in creating a plugin for tanzu CLI.
The plugin is added to the `tanzu-framework` repo and is built using the `Makefile`.

This particular plugin wraps `kubectl` (as installed on the user's machine) so it can be accessed through the tanzu CLI.

For example:
```
$ tanzu kubectl get pods -n capi-system
NAME                                       READY   STATUS    RESTARTS   AGE
capi-controller-manager-779dfd5797-6wpft   1/1     Running   0          22h
```

Shell completion works:
```
$ tanzu kubectl get pods -n cap<TAB>
capd-system                        capi-kubeadm-bootstrap-system      capi-kubeadm-control-plane-system  capi-system
```

The `kubectl describe` and `kubectl version` command don't work because they are shadowed by the plugin commands of the same name.

